### PR TITLE
add track.onended listener

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,6 +83,9 @@ function startStream() {
   pc2.onicecandidate = e => onIceCandidate(pc2, e);
   pc2.ontrack = gotRemoteStream;
   stream.getTracks().forEach(track => pc1.addTrack(track, stream));
+  stream.getTracks().forEach(track => {
+    track.addEventListener('ended', () => console.log('Track ended', track.kind, track));
+  });
   pc1.createOffer().then(gotDescription1).catch(error => console.warn);
 }
 


### PR DESCRIPTION
which should be called when the audio process ends prematurely. See
  https://bugs.chromium.org/p/chromium/issues/detail?id=1043040

@dchester can you take a look? I am curious if this is detectable. Also thank you for great steps to reproduce!